### PR TITLE
Corrections traductions  : états GPS en pt-PT raccourcis

### DIFF
--- a/Strings_pt.xml
+++ b/Strings_pt.xml
@@ -78,9 +78,9 @@
     <string name="notif_button">Parar e sair</string>
     
     <!-- GPS State -->
-    <string name="gps_wait">A procurar GPS…</string>
-    <string name="gps_pause">em pausa</string>
-    <string name="gps_old">localização desatualizada</string>
+    <string name="gps_wait">Aa procurar……</string>
+    <string name="gps_pause">Pausa</string>
+    <string name="gps_old">Loc antiga</string>
     <string name="gps_weak">Impreciso</string>
 
     <!-- Main -->


### PR DESCRIPTION
Traductions portugaises (pt-PT) raccourcies pour l'affichage des états GPS dans l'UI
